### PR TITLE
Connect frontend to backend

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -37,6 +37,11 @@ app = FastAPI(title="Evolance Research Portal")
 # Create a router with the /api prefix
 api_router = APIRouter(prefix="/api")
 
+@app.get("/ping")
+def ping():
+    """Health check endpoint."""
+    return {"message": "pong"}
+
 # Models
 class User(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
 WDS_SOCKET_PORT=443
-REACT_APP_BACKEND_URL=https://evolance.info
+REACT_APP_BACKEND_URL=https://research.evolance.info

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1077,6 +1077,13 @@ const ViewContext = React.createContext();
 function App() {
   const [currentView, setCurrentView] = useState('home');
 
+  useEffect(() => {
+    fetch(`${BACKEND_URL}/ping`)
+      .then((res) => res.json())
+      .then((data) => console.log('API Response:', data))
+      .catch((err) => console.error('API error', err));
+  }, []);
+
   const renderCurrentView = () => {
     switch(currentView) {
       case 'login': return <AuthForm isLogin={true} />;


### PR DESCRIPTION
## Summary
- add `/ping` endpoint for health check
- log ping response in frontend using `useEffect`
- set frontend backend URL to custom domain

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68560348969c83249733a4bf3d154654